### PR TITLE
Release version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# [unreleased]
+# ChessKitEngine 0.6.0
+Released Friday, May 30, 2025.
 
 ### Breaking Changes
 * `ChessKitEngine` now supports Swift 6 concurrency.


### PR DESCRIPTION
`ChessKitEngine 0.6.0` release candidate.