### PR TITLE
fix: bestmove output gets sometimes split on 2 lines

### DIFF
--- a/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.h
+++ b/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.h
@@ -25,6 +25,7 @@ NS_SWIFT_SENDABLE
 /// Engines work asynchronously so use this block to subscribe to
 /// any commands received from the engine.
 @property (nullable) void (^ responseHandler)(NSString * _Nonnull response);
+@property (nonatomic, strong) NSMutableString *outputBuffer;
 
 /// Initializes an engine with the desired type.
 ///

--- a/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.mm
+++ b/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.mm
@@ -26,6 +26,7 @@ NSLock *_lock;
 
   if (self) {
     _lock = [[NSLock alloc] init];
+    _outputBuffer = [NSMutableString string];
     switch (type) {
       case EngineTypeStockfish:
         _engine = new StockfishEngine();
@@ -105,15 +106,30 @@ NSLock *_lock;
 
 # pragma mark Private
 
-- (void)readStdout: (NSNotification*) notification {
-  [_pipeReadHandle readInBackgroundAndNotify];
-
-  NSData *data = [[notification userInfo] objectForKey:NSFileHandleNotificationDataItem];
-  NSArray<NSString *> *output = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] componentsSeparatedByString:@"\n"];
-
-  [output enumerateObjectsUsingBlock:^(NSString * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-    [self responseHandler](obj);
-  }];
+- (void)readStdout:(NSNotification*)notification {
+    [_pipeReadHandle readInBackgroundAndNotify];
+    
+    NSData *data = notification.userInfo[NSFileHandleNotificationDataItem];
+    if (!data || data.length == 0) return;
+    
+    NSString *chunk = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    if (!chunk) return;
+    
+    [self.outputBuffer appendString:chunk];
+    
+    NSArray<NSString *> *lines = [self.outputBuffer componentsSeparatedByString:@"\n"];
+    
+    // Keep the last line in the buffer if it's incomplete
+    NSUInteger lastIndex = lines.count - 1;
+    for (NSUInteger i = 0; i < lastIndex; i++) {
+        NSString *line = lines[i];
+        if (line.length > 0) {
+            [self responseHandler](line);
+        }
+    }
+    
+    // Reset the buffer with the last (possibly partial) line
+    [self.outputBuffer setString:lines[lastIndex]];
 }
 
 @end


### PR DESCRIPTION
The current implementation sometimes splits the bestmove response on 2 lines, this is related to the fact that the output can be chunked arbitrarily, especially when using NSFileHandle in async mode.

This fix ensures that every line entirely parsed once ready 