### PR TITLE
bugfix/signal_13_when_closing_read_pipe

### DIFF
--- a/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.mm
+++ b/Sources/ChessKitEngineCore/EngineMessenger/EngineMessenger.mm
@@ -5,6 +5,7 @@
 
 #import "EngineMessenger.h"
 #import "../Engines/AvailableEngines.h"
+#include <signal.h>
 
 @implementation EngineMessenger : NSObject
 
@@ -25,7 +26,8 @@ NSLock *_lock;
   self = [super init];
 
   if (self) {
-    _lock = [[NSLock alloc] init];
+    signal(SIGPIPE, SIG_IGN);
+   _lock = [[NSLock alloc] init];
     switch (type) {
       case EngineTypeStockfish:
         _engine = new StockfishEngine();
@@ -83,23 +85,53 @@ NSLock *_lock;
 
 - (void)stop {
   [_lock lock];
-  [_pipeReadHandle closeFile];
-  [_pipeWriteHandle closeFile];
 
-  _readPipe = NULL;
-  _pipeReadHandle = NULL;
+  // Remove read notifications before closing any handles
+  if (_pipeReadHandle) {
+      [[NSNotificationCenter defaultCenter] removeObserver:self name:NSFileHandleReadCompletionNotification object:_pipeReadHandle];
+  }
 
-  _writePipe = NULL;
-  _pipeWriteHandle = NULL;
+  // Close write side first to signal EOF to the reader and avoid further writes
+  if (_pipeWriteHandle) {
+      @try {
+          [_pipeWriteHandle closeAndReturnError:nil];
+      } @catch (NSException *exception) {
+          NSLog([exception description]);
+      }
+  }
 
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  _pipeWriteHandle = nil;
+  _writePipe = nil;
+
+  // Close read side
+  if (_pipeReadHandle) {
+    @try {
+      [_pipeReadHandle closeAndReturnError:nil];
+    } @catch (NSException *exception) {
+      NSLog([exception description]);
+    }
+  }
+
+  _pipeReadHandle = nil;
+  _readPipe = nil;
+
   [_lock unlock];
 }
 
 - (void)sendCommand: (NSString*) command {
   dispatch_sync(_queue, ^{
-    const char *cmd = [[command stringByAppendingString:@"\n"] UTF8String];
-    write([_pipeWriteHandle fileDescriptor], cmd, strlen(cmd));
+    if (!_pipeWriteHandle) { return; }
+    NSString *line = [command stringByAppendingString:@"\n"];
+    NSData *data = [line dataUsingEncoding:NSUTF8StringEncoding];
+    
+    if (!data) { return; }
+    
+    ssize_t fd = [_pipeWriteHandle fileDescriptor];
+    
+    if (fd < 0) { return; }
+
+    ssize_t result = write(fd, [data bytes], [data length]);
+    (void)result;
   });
 }
 


### PR DESCRIPTION
Sometimes when we stop the engine and close the read pipe we receive a signal 13, which leads to the app being terminated. This happens because we are still receiving new data after the read pipe was already closed. 

Admittedly this is more prevalent with Arasan Chess Engine which is not a part of this repo, but it might still happen with Stockfish and LC0. 

Changes done and their purpose.
- ignore SIGPIP if we encounter one during initialization.
- Ensure we remove the read observer before we try to close the pipes.
- Close and nullify write pipe and write file handler before closing read pipes.
- Replaced the call to the deprecated `closeFile` method with `closeAndReturnError:`.
- Added checks to ensure write pipe is still valid before sending new commands.

No new tests were added, as the changes that were made are already being covered by existing ones. 

Cheers!